### PR TITLE
normalize_regex is nil bug

### DIFF
--- a/lib/data_filter/like_filter.rb
+++ b/lib/data_filter/like_filter.rb
@@ -17,7 +17,7 @@ module DataFilter
     def initialize(field_sym, search_term, normalize_regex = /[^\w\s]/)
       @field_sym = field_sym
       @search_term = search_term
-      @normalize_regex = normalize_regex
+      @normalize_regex = normalize_regex.nil? ? /[^\w\s]/ : normalize_regex
     end
 
     # Filters the item

--- a/test/like_filter_test.rb
+++ b/test/like_filter_test.rb
@@ -102,5 +102,12 @@ module DataFilter
       el = OpenStruct.new(from: 'test-user+person@datto.com')
       assert_equal el, filter.call(el)
     end
+
+    it 'allows custom regex to be nil' do
+      # email characters in both filter and data
+      filter = DataFilter::LikeFilter.new(:from, 'Bobs Burgers', nil)
+      el = OpenStruct.new(from: 'Bobs Burgers')
+      assert_equal el, filter.call(el)
+    end
   end
 end


### PR DESCRIPTION
If the normalize_regex option is not provided, nil is passed in instead of using the default param. In this case, the whole like_filter breaks. This PR addresses that specific issue.
